### PR TITLE
ssl_not_required alias added for ssl_allowed

### DIFF
--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -50,6 +50,7 @@ module SslRequirement
     def ssl_allowed(*actions)
       write_inheritable_array(:ssl_allowed_actions, actions)
     end
+    alias_method :ssl_not_required, :ssl_allowed
   end
 
   protected
@@ -70,7 +71,6 @@ module SslRequirement
   def ssl_allowed?
     (self.class.read_inheritable_attribute(:ssl_allowed_actions) || []).include?(action_name.to_sym)
   end
-  alias_method :ssl_not_required, :ssl_allowed
 
   # normal ports are the ports used when no port is specified by the user to the browser
   # i.e. 80 if the protocol is http, 443 is the protocol is https

--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -56,7 +56,7 @@ module SslRequirement
   # Returns true if the current action is supposed to run as SSL
   def ssl_required?
     return true if SslRequirement.ssl_all?
-    
+
     required = (self.class.read_inheritable_attribute(:ssl_required_actions) || [])
     except  = self.class.read_inheritable_attribute(:ssl_required_except_actions)
 
@@ -70,6 +70,7 @@ module SslRequirement
   def ssl_allowed?
     (self.class.read_inheritable_attribute(:ssl_allowed_actions) || []).include?(action_name.to_sym)
   end
+  alias_method :ssl_not_required, :ssl_allowed
 
   # normal ports are the ports used when no port is specified by the user to the browser
   # i.e. 80 if the protocol is http, 443 is the protocol is https


### PR DESCRIPTION
Hi, 

I added an alias to ssl_allowed (ssl_not_required). We default to ssl for most pages our our sight but have a few where it's not required. It made more sense to have

 :ssl_not_required :action 

on these pages.

Thanks,
Dave
